### PR TITLE
fix Rails 5.1 deprecation warning

### DIFF
--- a/lib/mengpaneel/controller.rb
+++ b/lib/mengpaneel/controller.rb
@@ -7,7 +7,7 @@ module Mengpaneel
     extend ActiveSupport::Concern
 
     included do
-      prepend_around_filter :wrap_in_mengpaneel
+      prepend_around_action :wrap_in_mengpaneel
 
       delegate :mixpanel, to: :mengpaneel
 


### PR DESCRIPTION
DEPRECATION WARNING: prepend_around_filter is deprecated and will be
removed in Rails 5.1. Use prepend_around_action instead.