### PR TITLE
Fixed deprecation for rails 5+

### DIFF
--- a/lib/mengpaneel/controller.rb
+++ b/lib/mengpaneel/controller.rb
@@ -7,7 +7,11 @@ module Mengpaneel
     extend ActiveSupport::Concern
 
     included do
-      prepend_around_filter :wrap_in_mengpaneel
+      if Rails::VERSION::MAJOR >= 5
+        prepend_around_action :wrap_in_mengpaneel
+      else
+        prepend_around_filter :wrap_in_mengpaneel
+      end
 
       delegate :mixpanel, to: :mengpaneel
 


### PR DESCRIPTION
Rails 5.0 changed `around_filter` to `around_action`. This code used to break on Rails 5.1. This PR fixed it for Rails 5.1